### PR TITLE
Refactor the commands for correct binary name (`pleasant`)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 #IDEs
 .idea
+
+# Sensitive data / local configuration
+.pleasant.yaml

--- a/cmd/pleasant/commands/create.go
+++ b/cmd/pleasant/commands/create.go
@@ -1,5 +1,5 @@
-// Package pleasant /*
-package pleasant
+// Package commands /*
+package commands
 
 /*
 Copyright © 2021 David Lukac <david.lukac@users.noreply.github.com>
@@ -18,16 +18,12 @@ limitations under the License.
 */
 
 import (
-	"fmt"
-	"github.com/davidlukac/go-pleasant-cli/internal"
-	"strings"
-
 	"github.com/spf13/cobra"
 )
 
-// folderCmd represents the folder command
-var folderCmd = &cobra.Command{
-	Use:   "folder",
+// createCmd represents the create command
+var createCmd = &cobra.Command{
+	Use:   "create",
 	Short: "A brief description of your command",
 	Long: `A longer description that spans multiple lines and likely contains examples
 and usage of using your command. For example:
@@ -35,28 +31,8 @@ and usage of using your command. For example:
 Cobra is a CLI library for Go that empowers applications.
 This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
-	//Args: func(cmd *cobra.Command, args []string) error {
-	//
-	//},
-	Args: cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("folder called with %s\n", args[0])
-		parts := strings.Split(args[0], "/")
-		exists := internal.FoldersExist(parts, "")
-		fmt.Println(exists)
-	},
 }
 
 func init() {
-	existsCmd.AddCommand(folderCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// folderCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// folderCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	passwordServerCmd.AddCommand(createCmd)
 }

--- a/cmd/pleasant/commands/create_entry.go
+++ b/cmd/pleasant/commands/create_entry.go
@@ -1,5 +1,5 @@
-// Package pleasant /*
-package pleasant
+// Package commands /*
+package commands
 
 /*
 Copyright © 2021 David Lukac <david.lukac@users.noreply.github.com>
@@ -24,6 +24,7 @@ import (
 	"github.com/dchest/uniuri"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"golang.org/x/crypto/ssh/terminal"
 	"strings"
 	"syscall"
@@ -73,7 +74,12 @@ to quickly create a Cobra application.`,
 		}
 
 		if internal.EntryExistsByName(name, parentId) {
-			fmt.Printf("Entry with name %s already exists in folder %s. Please choose other name or use command line flags to override this check.", name, parentId)
+			entryId := internal.GetEntryIdByName(name, parentId)
+			if viper.GetBool("quiet") {
+				fmt.Println(entryId)
+			} else {
+				fmt.Printf("Entry with name %s already exists as %s in folder %s. Please choose other name or use command line flags to override this check.\n", name, entryId, parentId)
+			}
 			return
 		}
 
@@ -96,7 +102,11 @@ to quickly create a Cobra application.`,
 			GroupId:          parentId,
 		})
 
-		log.Info(fmt.Sprintf("Created new entry with ID %s", newEntry.Id))
+		if viper.GetBool("quiet") {
+			fmt.Println(newEntry.Id)
+		} else {
+			log.Info(fmt.Sprintf("Created new entry with ID %s", newEntry.Id))
+		}
 	},
 }
 

--- a/cmd/pleasant/commands/create_folder.go
+++ b/cmd/pleasant/commands/create_folder.go
@@ -1,5 +1,5 @@
-// Package pleasant /*
-package pleasant
+// Package commands /*
+package commands
 
 /*
 Copyright © 2021 David Lukac <david.lukac@users.noreply.github.com>
@@ -18,35 +18,33 @@ limitations under the License.
 */
 
 import (
+	"fmt"
+	"github.com/davidlukac/go-pleasant-cli/internal"
+	"strings"
+
 	"github.com/spf13/cobra"
 )
 
-// passwordServerCmd represents the passwordServer command
-var passwordServerCmd = &cobra.Command{
-	Use:     "password-server",
-	Aliases: []string{"ps"},
-	Short:   "A brief description of your command",
+// createFolderCmd represents the folder command
+var createFolderCmd = &cobra.Command{
+	Use:   "folder",
+	Short: "A brief description of your command",
 	Long: `A longer description that spans multiple lines and likely contains examples
 and usage of using your command. For example:
 
 Cobra is a CLI library for Go that empowers applications.
 This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
-	//Run: func(cmd *cobra.Command, args []string) {
-	//	fmt.Println("ps called")
-	//},
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("create folder called with %s\n", args[0])
+		pathParts := strings.Split(args[0], "/")
+		internal.CreateFolders(pathParts, "")
+		lastFolderId := internal.GetFolderIdFromPath(pathParts)
+		fmt.Println(lastFolderId)
+	},
 }
 
 func init() {
-	rootCmd.AddCommand(passwordServerCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// passwordServerCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// passwordServerCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	createCmd.AddCommand(createFolderCmd)
 }

--- a/cmd/pleasant/commands/exists.go
+++ b/cmd/pleasant/commands/exists.go
@@ -1,5 +1,5 @@
-// Package pleasant /*
-package pleasant
+// Package commands /*
+package commands
 
 /*
 Copyright © 2021 David Lukac <david.lukac@users.noreply.github.com>

--- a/cmd/pleasant/commands/exists_folder.go
+++ b/cmd/pleasant/commands/exists_folder.go
@@ -1,5 +1,5 @@
-// Package pleasant /*
-package pleasant
+// Package commands /*
+package commands
 
 /*
 Copyright © 2021 David Lukac <david.lukac@users.noreply.github.com>
@@ -18,12 +18,16 @@ limitations under the License.
 */
 
 import (
+	"fmt"
+	"github.com/davidlukac/go-pleasant-cli/internal"
+	"strings"
+
 	"github.com/spf13/cobra"
 )
 
-// getCmd represents the get command
-var getCmd = &cobra.Command{
-	Use:   "get",
+// folderCmd represents the folder command
+var folderCmd = &cobra.Command{
+	Use:   "folder",
 	Short: "A brief description of your command",
 	Long: `A longer description that spans multiple lines and likely contains examples
 and usage of using your command. For example:
@@ -31,21 +35,28 @@ and usage of using your command. For example:
 Cobra is a CLI library for Go that empowers applications.
 This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
-	//Run: func(cmd *cobra.Command, args []string) {
-	//	fmt.Printf("get called with %s\n", args)
+	//Args: func(cmd *cobra.Command, args []string) error {
+	//
 	//},
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("folder called with %s\n", args[0])
+		parts := strings.Split(args[0], "/")
+		exists := internal.FoldersExist(parts, "")
+		fmt.Println(exists)
+	},
 }
 
 func init() {
-	passwordServerCmd.AddCommand(getCmd)
+	existsCmd.AddCommand(folderCmd)
 
 	// Here you will define your flags and configuration settings.
 
 	// Cobra supports Persistent Flags which will work for this command
 	// and all subcommands, e.g.:
-	// getCmd.PersistentFlags().String("foo", "", "A help for foo")
+	// folderCmd.PersistentFlags().String("foo", "", "A help for foo")
 
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
-	// getCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	// folderCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/pleasant/commands/get.go
+++ b/cmd/pleasant/commands/get.go
@@ -1,5 +1,5 @@
-// Package pleasant /*
-package pleasant
+// Package commands /*
+package commands
 
 /*
 Copyright © 2021 David Lukac <david.lukac@users.noreply.github.com>
@@ -18,15 +18,12 @@ limitations under the License.
 */
 
 import (
-	"fmt"
-	"github.com/davidlukac/go-pleasant-cli/internal"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
-// loginCmd represents the login command
-var loginCmd = &cobra.Command{
-	Use:   "login",
+// getCmd represents the get command
+var getCmd = &cobra.Command{
+	Use:   "get",
 	Short: "A brief description of your command",
 	Long: `A longer description that spans multiple lines and likely contains examples
 and usage of using your command. For example:
@@ -34,22 +31,21 @@ and usage of using your command. For example:
 Cobra is a CLI library for Go that empowers applications.
 This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		vault := internal.GetVault()
-		log.Infoln(fmt.Sprintf("Logged in as %s@%s", vault.Username, vault.URL))
-	},
+	//Run: func(cmd *cobra.Command, args []string) {
+	//	fmt.Printf("get called with %s\n", args)
+	//},
 }
 
 func init() {
-	passwordServerCmd.AddCommand(loginCmd)
+	passwordServerCmd.AddCommand(getCmd)
 
 	// Here you will define your flags and configuration settings.
 
 	// Cobra supports Persistent Flags which will work for this command
 	// and all subcommands, e.g.:
-	// loginCmd.PersistentFlags().String("foo", "", "A help for foo")
+	// getCmd.PersistentFlags().String("foo", "", "A help for foo")
 
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
-	// loginCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	// getCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/pleasant/commands/get_entry.go
+++ b/cmd/pleasant/commands/get_entry.go
@@ -1,5 +1,5 @@
-// Package pleasant /*
-package pleasant
+// Package commands /*
+package commands
 
 /*
 Copyright © 2021 David Lukac <david.lukac@users.noreply.github.com>
@@ -18,12 +18,15 @@ limitations under the License.
 */
 
 import (
+	"fmt"
+	"github.com/davidlukac/go-pleasant-cli/internal"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
-// createCmd represents the create command
-var createCmd = &cobra.Command{
-	Use:   "create",
+// entryCmd represents the entry command
+var entryCmd = &cobra.Command{
+	Use:   "entry",
 	Short: "A brief description of your command",
 	Long: `A longer description that spans multiple lines and likely contains examples
 and usage of using your command. For example:
@@ -31,21 +34,23 @@ and usage of using your command. For example:
 Cobra is a CLI library for Go that empowers applications.
 This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
-	//Run: func(cmd *cobra.Command, args []string) {
-	//	fmt.Println("create called")
-	//},
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		log.Infoln(fmt.Sprintf("get entry called with %s", args[0]))
+		fmt.Println(internal.GetEntry(args[0]))
+	},
 }
 
 func init() {
-	passwordServerCmd.AddCommand(createCmd)
+	getCmd.AddCommand(entryCmd)
 
 	// Here you will define your flags and configuration settings.
 
 	// Cobra supports Persistent Flags which will work for this command
 	// and all subcommands, e.g.:
-	// createCmd.PersistentFlags().String("foo", "", "A help for foo")
+	// entryCmd.PersistentFlags().String("foo", "", "A help for foo")
 
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
-	// createCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	// entryCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/pleasant/commands/get_folder.go
+++ b/cmd/pleasant/commands/get_folder.go
@@ -1,5 +1,5 @@
-// Package pleasant /*
-package pleasant
+// Package commands /*
+package commands
 
 /*
 Copyright © 2021 David Lukac <david.lukac@users.noreply.github.com>

--- a/cmd/pleasant/commands/login.go
+++ b/cmd/pleasant/commands/login.go
@@ -1,5 +1,5 @@
-// Package pleasant /*
-package pleasant
+// Package commands /*
+package commands
 
 /*
 Copyright © 2021 David Lukac <david.lukac@users.noreply.github.com>
@@ -24,9 +24,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// entryCmd represents the entry command
-var entryCmd = &cobra.Command{
-	Use:   "entry",
+// loginCmd represents the login command
+var loginCmd = &cobra.Command{
+	Use:   "login",
 	Short: "A brief description of your command",
 	Long: `A longer description that spans multiple lines and likely contains examples
 and usage of using your command. For example:
@@ -34,23 +34,22 @@ and usage of using your command. For example:
 Cobra is a CLI library for Go that empowers applications.
 This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
-	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		log.Infoln(fmt.Sprintf("get entry called with %s", args[0]))
-		fmt.Println(internal.GetEntry(args[0]))
+		vault := internal.GetVault()
+		log.Infoln(fmt.Sprintf("Logged in as %s@%s", vault.Username, vault.URL))
 	},
 }
 
 func init() {
-	getCmd.AddCommand(entryCmd)
+	passwordServerCmd.AddCommand(loginCmd)
 
 	// Here you will define your flags and configuration settings.
 
 	// Cobra supports Persistent Flags which will work for this command
 	// and all subcommands, e.g.:
-	// entryCmd.PersistentFlags().String("foo", "", "A help for foo")
+	// loginCmd.PersistentFlags().String("foo", "", "A help for foo")
 
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
-	// entryCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	// loginCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/pleasant/commands/password_server.go
+++ b/cmd/pleasant/commands/password_server.go
@@ -1,5 +1,5 @@
-// Package pleasant /*
-package pleasant
+// Package commands /*
+package commands
 
 /*
 Copyright © 2021 David Lukac <david.lukac@users.noreply.github.com>
@@ -18,43 +18,35 @@ limitations under the License.
 */
 
 import (
-	"fmt"
-	"github.com/davidlukac/go-pleasant-cli/internal"
-	"strings"
-
 	"github.com/spf13/cobra"
 )
 
-// createFolderCmd represents the folder command
-var createFolderCmd = &cobra.Command{
-	Use:   "folder",
-	Short: "A brief description of your command",
+// passwordServerCmd represents the passwordServer command
+var passwordServerCmd = &cobra.Command{
+	Use:     "password-server",
+	Aliases: []string{"ps"},
+	Short:   "A brief description of your command",
 	Long: `A longer description that spans multiple lines and likely contains examples
 and usage of using your command. For example:
 
 Cobra is a CLI library for Go that empowers applications.
 This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
-	Args: cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("create folder called with %s\n", args[0])
-		pathParts := strings.Split(args[0], "/")
-		internal.CreateFolders(pathParts, "")
-		lastFolderId := internal.GetFolderIdFromPath(pathParts)
-		fmt.Println(lastFolderId)
-	},
+	//Run: func(cmd *cobra.Command, args []string) {
+	//	fmt.Println("ps called")
+	//},
 }
 
 func init() {
-	createCmd.AddCommand(createFolderCmd)
+	rootCmd.AddCommand(passwordServerCmd)
 
 	// Here you will define your flags and configuration settings.
 
 	// Cobra supports Persistent Flags which will work for this command
 	// and all subcommands, e.g.:
-	// createFolderCmd.PersistentFlags().String("foo", "", "A help for foo")
+	// passwordServerCmd.PersistentFlags().String("foo", "", "A help for foo")
 
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
-	// createFolderCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	// passwordServerCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/pleasant/commands/root.go
+++ b/cmd/pleasant/commands/root.go
@@ -1,5 +1,5 @@
-// Package pleasant /*
-package pleasant
+// Package commands /*
+package commands
 
 /*
 Copyright © 2021 David Lukac <david.lukac@users.noreply.github.com>
@@ -19,13 +19,14 @@ limitations under the License.
 
 import (
 	"fmt"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"os"
-
 	"github.com/spf13/viper"
+	"os"
 )
 
 var cfgFile string
+var quiet = false
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -37,9 +38,6 @@ examples and usage of using your application. For example:
 Cobra is a CLI library for Go that empowers applications.
 This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
-	// Uncomment the following line if your bare application
-	// has an action associated with it:
-	//Run: func(cmd *cobra.Command, args []string) { },
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -52,6 +50,11 @@ func init() {
 	cobra.OnInitialize(initConfig)
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.plesant.yaml)")
+	rootCmd.PersistentFlags().BoolVarP(&quiet, "quiet", "q", false, "Minimal output")
+	err := viper.BindPFlag("quiet", rootCmd.PersistentFlags().Lookup("quiet"))
+	if err != nil {
+		return
+	}
 
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }
@@ -81,8 +84,12 @@ func initConfig() {
 
 	viper.AutomaticEnv() // read in environment variables that match
 
+	if quiet {
+		logrus.SetLevel(logrus.ErrorLevel)
+	}
+
 	// If a config file is found, read it in.
-	if err := viper.ReadInConfig(); err == nil {
+	if err := viper.ReadInConfig(); err == nil && !quiet {
 		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
 	}
 }

--- a/cmd/pleasant/pleasant.go
+++ b/cmd/pleasant/pleasant.go
@@ -18,11 +18,9 @@ limitations under the License.
 */
 
 import (
-	"github.com/davidlukac/go-pleasant-cli/cmd/pleasant"
-	log "github.com/sirupsen/logrus"
+	"github.com/davidlukac/go-pleasant-cli/cmd/pleasant/commands"
 )
 
 func main() {
-	log.Info("Main")
-	pleasant.Execute()
+	commands.Execute()
 }

--- a/internal/entryRepository.go
+++ b/internal/entryRepository.go
@@ -31,3 +31,17 @@ func EntryExistsByName(name string, parentId string) bool {
 
 	return false
 }
+
+// GetEntryIdByName returns entry ID if it exists, otherwise empty string.
+func GetEntryIdByName(name string, parentId string) string {
+	vault := GetVault()
+	folder := vault.GetFolder(parentId)
+
+	for _, c := range folder.Credentials {
+		if c.Name == name {
+			return c.Id
+		}
+	}
+
+	return ""
+}


### PR DESCRIPTION
- Add `quiet` flag to `ps create entry` command to minimise output so we can use it in scripts
- Add `GetEntryIdByName` to `entryRepository`